### PR TITLE
Add Vault support for production secrets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,4 @@ MINIO_ACCESS_NAME: minio_name
 MINIO_ACCESS_SECRET: minio_secret
 MINIO_BUCKET_NAME: mybucket
 NEW_RELIC_LICENSE_KEY: your_newrelic_key
+VAULT_TOKEN: your_vault_token

--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,4 @@ MINIO_ACCESS_SECRET: minio_secret
 MINIO_BUCKET_NAME: mybucket
 NEW_RELIC_LICENSE_KEY: your_newrelic_key
 VAULT_TOKEN: your_vault_token
+SPLUNK_TOKEN: your_splunk_token

--- a/README.md
+++ b/README.md
@@ -9,3 +9,7 @@ The application uses the New Relic Java agent located in the `newrelic` director
 ## Production secrets
 
 When running with the `prod` profile, secret values are retrieved from the Hashicorp Vault instance at `https://vault.leultewolde.com`. The application expects a `VAULT_TOKEN` environment variable for authentication. Secrets such as database credentials and MinIO access keys must be stored in Vault with the same property names used in `application-prod.properties`.
+
+## Splunk logging
+
+When the `prod` profile is active, logs are also sent to Splunk using the HTTP Event Collector. The Splunk instance is available at `http://10.0.0.222:8000/`. Store the `SPLUNK_TOKEN` in Vault so it can be injected at runtime.

--- a/README.md
+++ b/README.md
@@ -5,3 +5,7 @@ This service manages ingredients and prepared foods. After starting the applicat
 ## New Relic configuration
 
 The application uses the New Relic Java agent located in the `newrelic` directory. Provide your license key via the `NEW_RELIC_LICENSE_KEY` environment variable or `.env` file. The included `newrelic.yml` loads the key from that variable.
+
+## Production secrets
+
+When running with the `prod` profile, secret values are retrieved from the Hashicorp Vault instance at `https://vault.leultewolde.com`. The application expects a `VAULT_TOKEN` environment variable for authentication. Secrets such as database credentials and MinIO access keys must be stored in Vault with the same property names used in `application-prod.properties`.

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,12 @@ repositories {
     mavenCentral()
 }
 
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:2023.0.1"
+    }
+}
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -37,6 +43,7 @@ dependencies {
     runtimeOnly 'org.postgresql:postgresql'
     implementation("io.minio:minio:8.5.17")
     implementation 'org.mapstruct:mapstruct:1.5.5.Final'
+    implementation 'org.springframework.cloud:spring-cloud-starter-vault-config'
     annotationProcessor 'org.projectlombok:lombok'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
     annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     implementation("io.minio:minio:8.5.17")
     implementation 'org.mapstruct:mapstruct:1.5.5.Final'
     implementation 'org.springframework.cloud:spring-cloud-starter-vault-config'
+    implementation 'com.splunk.logging:splunk-library-javalogging:1.11.3'
     annotationProcessor 'org.projectlombok:lombok'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
     annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -14,3 +14,8 @@ minio.url=${MINIO_URL}
 minio.access-name=${MINIO_ACCESS_NAME}
 minio.access-secret=${MINIO_ACCESS_SECRET}
 minio.bucket-name=${MINIO_BUCKET}
+
+# Splunk logging
+splunk.enabled=true
+splunk.url=http://10.0.0.222:8000/
+splunk.token=${SPLUNK_TOKEN}

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,3 +1,10 @@
+spring.config.import=vault://
+
+spring.cloud.vault.enabled=true
+spring.cloud.vault.uri=https://vault.leultewolde.com
+spring.cloud.vault.authentication=token
+spring.cloud.vault.token=${VAULT_TOKEN}
+
 spring.datasource.url=${DB_URL}
 spring.datasource.username=${DB_USER}
 spring.datasource.password=${DB_PASSWORD}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,3 +13,7 @@ logging.level.com.yourcompany=DEBUG
 
 # Log format
 logging.pattern.console=%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n
+
+# Disable Vault integration by default. Production profile enables it.
+spring.cloud.vault.enabled=false
+spring.cloud.compatibility-verifier.enabled=false

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -17,3 +17,6 @@ logging.pattern.console=%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} -
 # Disable Vault integration by default. Production profile enables it.
 spring.cloud.vault.enabled=false
 spring.cloud.compatibility-verifier.enabled=false
+
+# Disable Splunk logging by default
+splunk.enabled=false

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,24 @@
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE" />
+    </root>
+
+    <springProfile name="prod">
+        <property name="SPLUNK_URL" value="${splunk.url}" />
+        <property name="SPLUNK_TOKEN" value="${splunk.token}" />
+        <appender name="SPLUNK" class="com.splunk.logging.HttpEventCollectorLogbackAppender">
+            <url>${SPLUNK_URL}</url>
+            <token>${SPLUNK_TOKEN}</token>
+            <layout class="ch.qos.logback.classic.PatternLayout">
+                <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+            </layout>
+        </appender>
+        <root level="INFO">
+            <appender-ref ref="CONSOLE" />
+            <appender-ref ref="SPLUNK" />
+        </root>
+    </springProfile>
+</configuration>


### PR DESCRIPTION
## Summary
- configure Spring Cloud Vault dependency
- use Vault for production configuration
- document Vault usage in README and `.env.example`
- disable Spring Cloud compatibility checks and Vault in non-prod profiles

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6867d967833c832cbe4f0eb970fe8acc