### PR TITLE
Retrieve New Relic license from Vault

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,12 @@ RUN gradle clean bootJar --no-daemon
 
 FROM eclipse-temurin:24-jre
 WORKDIR /app
+RUN apt-get update && apt-get install -y curl jq \
+    && rm -rf /var/lib/apt/lists/*
 COPY --from=build /app/build/libs/km-ingredients-service-*.jar app.jar
 COPY newrelic/ /newrelic/
+COPY docker-entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 EXPOSE 8080
-ENTRYPOINT ["java", "-javaagent:/newrelic/newrelic.jar", "-jar", "app.jar"]
+ENTRYPOINT ["/entrypoint.sh"]
+

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This service manages ingredients and prepared foods. After starting the applicat
 
 ## New Relic configuration
 
-The application uses the New Relic Java agent located in the `newrelic` directory. Provide your license key via the `NEW_RELIC_LICENSE_KEY` environment variable or `.env` file. The included `newrelic.yml` loads the key from that variable.
+The application uses the New Relic Java agent located in the `newrelic` directory. During container start-up the `docker-entrypoint.sh` script retrieves the `NEW_RELIC_LICENSE_KEY` from Hashicorp Vault (using the `VAULT_TOKEN`) and exports it for the agent. The included `newrelic.yml` reads the key from this environment variable.
 
 ## Production secrets
 

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ configurations {
 
 repositories {
     mavenCentral()
+    maven { url 'https://splunk.jfrog.io/splunk/ext-release-local' }
 }
 
 dependencyManagement {
@@ -44,7 +45,7 @@ dependencies {
     implementation("io.minio:minio:8.5.17")
     implementation 'org.mapstruct:mapstruct:1.5.5.Final'
     implementation 'org.springframework.cloud:spring-cloud-starter-vault-config'
-    implementation 'com.splunk.logging:splunk-library-javalogging:1.11.3'
+    implementation 'com.splunk.logging:splunk-library-javalogging:1.9.0'
     annotationProcessor 'org.projectlombok:lombok'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
     annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+# Fetch New Relic license key from Hashicorp Vault if VAULT_TOKEN is provided
+if [ -n "$VAULT_TOKEN" ]; then
+  VAULT_URL="${VAULT_ADDR:-https://vault.leultewolde.com}"
+  VAULT_PATH="${VAULT_NEW_RELIC_PATH:-secret/data/newrelic}"
+  LICENSE=$(curl -sf -H "X-Vault-Token: $VAULT_TOKEN" "$VAULT_URL/v1/$VAULT_PATH" | jq -r '.data.data.NEW_RELIC_LICENSE_KEY // .data.data.license_key // empty')
+  if [ -n "$LICENSE" ]; then
+    export NEW_RELIC_LICENSE_KEY="$LICENSE"
+  fi
+fi
+
+exec java -javaagent:/newrelic/newrelic.jar -jar app.jar
+


### PR DESCRIPTION
## Summary
- fetch New Relic license from Hashicorp Vault before starting the app
- run container using new `docker-entrypoint.sh`
- document license key retrieval in README
- add Splunk repo to Gradle build
- use Splunk Java logging 1.9.0

## Testing
- `./gradlew test --stacktrace` *(fails: Could not resolve com.splunk.logging:splunk-library-javalogging:1.9.0 from splunk.jfrog.io)*

------
https://chatgpt.com/codex/tasks/task_e_6867f82c8374832c9585fd675cdff978