### PR TITLE
Implement pagination and websocket endpoints

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.h2database:h2'

--- a/src/main/java/com/leultewolde/hidmo/kmingredientsservice/config/WebSocketConfig.java
+++ b/src/main/java/com/leultewolde/hidmo/kmingredientsservice/config/WebSocketConfig.java
@@ -1,0 +1,22 @@
+package com.leultewolde.hidmo.kmingredientsservice.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws").setAllowedOriginPatterns("*");
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/topic");
+        registry.setApplicationDestinationPrefixes("/app");
+    }
+}

--- a/src/main/java/com/leultewolde/hidmo/kmingredientsservice/controller/IngredientController.java
+++ b/src/main/java/com/leultewolde/hidmo/kmingredientsservice/controller/IngredientController.java
@@ -7,6 +7,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.data.domain.PageRequest;
 
 import java.util.List;
 import java.util.UUID;
@@ -19,8 +20,10 @@ public class IngredientController {
     private final IngredientService service;
 
     @GetMapping
-    public ResponseEntity<List<IngredientResponseDTO>> getAll() {
-        return ResponseEntity.ok(service.getAll());
+    public ResponseEntity<List<IngredientResponseDTO>> getAll(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        return ResponseEntity.ok(service.getAll(PageRequest.of(page, size)));
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/leultewolde/hidmo/kmingredientsservice/controller/IngredientWebSocketController.java
+++ b/src/main/java/com/leultewolde/hidmo/kmingredientsservice/controller/IngredientWebSocketController.java
@@ -1,0 +1,33 @@
+package com.leultewolde.hidmo.kmingredientsservice.controller;
+
+import com.leultewolde.hidmo.kmingredientsservice.dto.response.IngredientResponseDTO;
+import com.leultewolde.hidmo.kmingredientsservice.dto.response.PreparedFoodResponseDTO;
+import com.leultewolde.hidmo.kmingredientsservice.service.IngredientService;
+import com.leultewolde.hidmo.kmingredientsservice.service.PreparedFoodService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.stereotype.Controller;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.List;
+
+@Controller
+@RequiredArgsConstructor
+public class IngredientWebSocketController {
+
+    private final IngredientService ingredientService;
+    private final PreparedFoodService preparedFoodService;
+
+    @MessageMapping("/ingredients")
+    @SendTo("/topic/ingredients")
+    public List<IngredientResponseDTO> streamIngredients() {
+        return ingredientService.getAll(PageRequest.of(0, 20));
+    }
+
+    @MessageMapping("/prepared-foods")
+    @SendTo("/topic/prepared-foods")
+    public List<PreparedFoodResponseDTO> streamPreparedFoods() {
+        return preparedFoodService.getAllPreparedFoods(PageRequest.of(0, 20));
+    }
+}

--- a/src/main/java/com/leultewolde/hidmo/kmingredientsservice/controller/PreparedFoodController.java
+++ b/src/main/java/com/leultewolde/hidmo/kmingredientsservice/controller/PreparedFoodController.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.data.domain.PageRequest;
 
 import java.util.List;
 
@@ -25,8 +26,10 @@ public class PreparedFoodController {
     }
 
     @GetMapping
-    public ResponseEntity<List<PreparedFoodResponseDTO>> getAll() {
-        return ResponseEntity.ok(preparedFoodService.getAllPreparedFoods());
+    public ResponseEntity<List<PreparedFoodResponseDTO>> getAll(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        return ResponseEntity.ok(preparedFoodService.getAllPreparedFoods(PageRequest.of(page, size)));
     }
 }
 

--- a/src/main/java/com/leultewolde/hidmo/kmingredientsservice/service/IngredientService.java
+++ b/src/main/java/com/leultewolde/hidmo/kmingredientsservice/service/IngredientService.java
@@ -10,6 +10,7 @@ import com.leultewolde.hidmo.kmingredientsservice.repository.IngredientRepositor
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.UUID;
@@ -21,8 +22,8 @@ public class IngredientService {
     private final IngredientRepository repo;
     private final IngredientMapper mapper;
 
-    public List<IngredientResponseDTO> getAll() {
-        return repo.findAll().stream().map(mapper::toDTO).toList();
+    public List<IngredientResponseDTO> getAll(Pageable pageable) {
+        return repo.findAll(pageable).stream().map(mapper::toDTO).toList();
     }
 
     public IngredientResponseDTO getById(UUID id) {

--- a/src/main/java/com/leultewolde/hidmo/kmingredientsservice/service/PreparedFoodService.java
+++ b/src/main/java/com/leultewolde/hidmo/kmingredientsservice/service/PreparedFoodService.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
@@ -58,8 +59,8 @@ public class PreparedFoodService {
     }
 
     @Transactional(readOnly = true)
-    public List<PreparedFoodResponseDTO> getAllPreparedFoods() {
-        return preparedFoodRepo.findAll().stream()
+    public List<PreparedFoodResponseDTO> getAllPreparedFoods(Pageable pageable) {
+        return preparedFoodRepo.findAll(pageable).stream()
                 .map(mapper::toDTO)
                 .toList();
     }

--- a/src/test/java/com/leultewolde/hidmo/kmingredientsservice/component/PreparedFoodComponentTest.java
+++ b/src/test/java/com/leultewolde/hidmo/kmingredientsservice/component/PreparedFoodComponentTest.java
@@ -70,7 +70,7 @@ class PreparedFoodComponentTest {
 
     @Test
     void shouldListAllPreparedFoods() {
-        List<PreparedFoodResponseDTO> all = preparedFoodService.getAllPreparedFoods();
+        List<PreparedFoodResponseDTO> all = preparedFoodService.getAllPreparedFoods(org.springframework.data.domain.PageRequest.of(0, 20));
         assertNotNull(all);
     }
 }

--- a/src/test/java/com/leultewolde/hidmo/kmingredientsservice/controller/IngredientControllerTest.java
+++ b/src/test/java/com/leultewolde/hidmo/kmingredientsservice/controller/IngredientControllerTest.java
@@ -31,7 +31,7 @@ class IngredientControllerTest {
         IngredientResponseDTO dto = new IngredientResponseDTO();
         dto.setName("Sugar");
 
-        when(service.getAll()).thenReturn(List.of(dto));
+        when(service.getAll(any(org.springframework.data.domain.Pageable.class))).thenReturn(List.of(dto));
 
         mockMvc.perform(get("/v1/ingredients"))
                 .andExpect(status().isOk())

--- a/src/test/java/com/leultewolde/hidmo/kmingredientsservice/controller/PreparedFoodControllerTest.java
+++ b/src/test/java/com/leultewolde/hidmo/kmingredientsservice/controller/PreparedFoodControllerTest.java
@@ -30,7 +30,7 @@ class PreparedFoodControllerTest {
         PreparedFoodResponseDTO responseDTO = new PreparedFoodResponseDTO();
         responseDTO.setName("Sauce");
 
-        when(service.getAllPreparedFoods()).thenReturn(List.of(responseDTO));
+        when(service.getAllPreparedFoods(any(org.springframework.data.domain.Pageable.class))).thenReturn(List.of(responseDTO));
 
         mockMvc.perform(get("/v1/prepared-foods"))
                 .andExpect(status().isOk())

--- a/src/test/java/com/leultewolde/hidmo/kmingredientsservice/service/IngredientServiceTest.java
+++ b/src/test/java/com/leultewolde/hidmo/kmingredientsservice/service/IngredientServiceTest.java
@@ -71,10 +71,10 @@ class IngredientServiceTest {
         ing.setId(UUID.randomUUID());
         ing.setName("Salt");
 
-        when(repo.findAll()).thenReturn(List.of(ing));
+        when(repo.findAll(any(org.springframework.data.domain.Pageable.class))).thenReturn(new org.springframework.data.domain.PageImpl<>(List.of(ing)));
         when(mapper.toDTO(any())).thenReturn(dto);
 
-        List<IngredientResponseDTO> result = service.getAll();
+        List<IngredientResponseDTO> result = service.getAll(org.springframework.data.domain.Pageable.unpaged());
         assertEquals(1, result.size());
         assertEquals("Salt", result.getFirst().getName());
     }

--- a/src/test/java/com/leultewolde/hidmo/kmingredientsservice/service/PreparedFoodServiceTest.java
+++ b/src/test/java/com/leultewolde/hidmo/kmingredientsservice/service/PreparedFoodServiceTest.java
@@ -101,10 +101,10 @@ class PreparedFoodServiceTest {
         PreparedFoodResponseDTO dto = new PreparedFoodResponseDTO();
         dto.setName("Leftovers");
 
-        when(preparedFoodRepo.findAll()).thenReturn(List.of(food));
+        when(preparedFoodRepo.findAll(any(org.springframework.data.domain.Pageable.class))).thenReturn(new org.springframework.data.domain.PageImpl<>(List.of(food)));
         when(preparedFoodMapper.toDTO(any())).thenReturn(dto);
 
-        List<PreparedFoodResponseDTO> result = service.getAllPreparedFoods();
+        List<PreparedFoodResponseDTO> result = service.getAllPreparedFoods(org.springframework.data.domain.Pageable.unpaged());
         assertEquals(1, result.size());
         assertEquals("Leftovers", result.getFirst().getName());
     }

--- a/src/test/java/com/leultewolde/hidmo/kmingredientsservice/websocket/IngredientWebSocketControllerTest.java
+++ b/src/test/java/com/leultewolde/hidmo/kmingredientsservice/websocket/IngredientWebSocketControllerTest.java
@@ -1,0 +1,55 @@
+package com.leultewolde.hidmo.kmingredientsservice.websocket;
+
+import com.leultewolde.hidmo.kmingredientsservice.controller.IngredientWebSocketController;
+import com.leultewolde.hidmo.kmingredientsservice.dto.response.IngredientResponseDTO;
+import com.leultewolde.hidmo.kmingredientsservice.dto.response.PreparedFoodResponseDTO;
+import com.leultewolde.hidmo.kmingredientsservice.service.IngredientService;
+import com.leultewolde.hidmo.kmingredientsservice.service.PreparedFoodService;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class IngredientWebSocketControllerTest {
+
+    @Mock
+    private IngredientService ingredientService;
+    @Mock
+    private PreparedFoodService preparedFoodService;
+
+    @InjectMocks
+    private IngredientWebSocketController controller;
+
+    @Test
+    void streamIngredientsReturnsList() {
+        IngredientResponseDTO dto = new IngredientResponseDTO();
+        dto.setId(UUID.randomUUID());
+        dto.setName("Cheese");
+        when(ingredientService.getAll(org.springframework.data.domain.PageRequest.of(0,20)))
+                .thenReturn(List.of(dto));
+
+        List<IngredientResponseDTO> result = controller.streamIngredients();
+        assertEquals(1, result.size());
+        assertEquals("Cheese", result.getFirst().getName());
+    }
+
+    @Test
+    void streamPreparedFoodsReturnsList() {
+        PreparedFoodResponseDTO dto = new PreparedFoodResponseDTO();
+        dto.setName("Soup");
+        when(preparedFoodService.getAllPreparedFoods(org.springframework.data.domain.PageRequest.of(0,20)))
+                .thenReturn(List.of(dto));
+
+        List<PreparedFoodResponseDTO> result = controller.streamPreparedFoods();
+        assertEquals(1, result.size());
+        assertEquals("Soup", result.getFirst().getName());
+    }
+}


### PR DESCRIPTION
## Summary
- add spring websocket dependency and configuration
- expose websocket controller for streaming ingredient and prepared food lists
- add page & size parameters to ingredient and prepared food controllers
- support pagination in service layers
- update tests and add new websocket unit test

## Testing
- `./gradlew test --no-daemon` *(fails: IllegalStateException during context initialization)*

------
https://chatgpt.com/codex/tasks/task_e_686977198db4832caa02efc5ab699842