### PR TITLE
Update prepared food and ingredient management

### DIFF
--- a/src/main/java/com/leultewolde/hidmo/kmingredientsservice/controller/PreparedFoodController.java
+++ b/src/main/java/com/leultewolde/hidmo/kmingredientsservice/controller/PreparedFoodController.java
@@ -10,6 +10,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.data.domain.PageRequest;
 
+import java.util.UUID;
+
 import java.util.List;
 
 @RestController
@@ -30,6 +32,12 @@ public class PreparedFoodController {
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size) {
         return ResponseEntity.ok(preparedFoodService.getAllPreparedFoods(PageRequest.of(page, size)));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable UUID id) {
+        preparedFoodService.deletePreparedFood(id);
+        return ResponseEntity.noContent().build();
     }
 }
 

--- a/src/test/java/com/leultewolde/hidmo/kmingredientsservice/controller/PreparedFoodControllerTest.java
+++ b/src/test/java/com/leultewolde/hidmo/kmingredientsservice/controller/PreparedFoodControllerTest.java
@@ -16,6 +16,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(PreparedFoodController.class)
@@ -88,5 +89,14 @@ class PreparedFoodControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(invalidJson))
                 .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void shouldDeletePreparedFood() throws Exception {
+        UUID id = UUID.randomUUID();
+        org.mockito.Mockito.doNothing().when(service).deletePreparedFood(id);
+
+        mockMvc.perform(delete("/v1/prepared-foods/" + id))
+                .andExpect(status().isNoContent());
     }
 }

--- a/src/test/java/com/leultewolde/hidmo/kmingredientsservice/integration/PreparedFoodControllerIT.java
+++ b/src/test/java/com/leultewolde/hidmo/kmingredientsservice/integration/PreparedFoodControllerIT.java
@@ -6,6 +6,7 @@ import com.leultewolde.hidmo.kmingredientsservice.dto.request.IngredientUsageReq
 import com.leultewolde.hidmo.kmingredientsservice.dto.request.PreparedFoodRequestDTO;
 import com.leultewolde.hidmo.kmingredientsservice.model.IngredientStatus;
 import com.leultewolde.hidmo.kmingredientsservice.service.IngredientService;
+import com.leultewolde.hidmo.kmingredientsservice.repository.PreparedFoodRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,6 +33,7 @@ class PreparedFoodControllerIT {
     @Autowired private MockMvc mockMvc;
     @Autowired private ObjectMapper objectMapper;
     @Autowired private IngredientService ingredientService;
+    @Autowired private PreparedFoodRepository preparedFoodRepository;
 
     private UUID ingredientId;
 
@@ -76,6 +78,26 @@ class PreparedFoodControllerIT {
         mockMvc.perform(get("/v1/prepared-foods"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$").isArray());
+    }
+
+    @Test
+    void shouldDeletePreparedFood() throws Exception {
+        PreparedFoodRequestDTO dto = new PreparedFoodRequestDTO(
+                "Chili Paste", new BigDecimal("1"), "jar",
+                LocalDate.now(), LocalDate.now().plusDays(1),
+                "Fridge", IngredientStatus.AVAILABLE, null,
+                List.of(new IngredientUsageRequestDTO(ingredientId, BigDecimal.ONE))
+        );
+
+        mockMvc.perform(post("/v1/prepared-foods")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isCreated());
+
+        UUID foodId = preparedFoodRepository.findAll().getFirst().getId();
+
+        mockMvc.perform(delete("/v1/prepared-foods/" + foodId))
+                .andExpect(status().isNoContent());
     }
 
     @Test

--- a/src/test/java/com/leultewolde/hidmo/kmingredientsservice/service/IngredientServiceTest.java
+++ b/src/test/java/com/leultewolde/hidmo/kmingredientsservice/service/IngredientServiceTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -18,6 +19,7 @@ import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -26,6 +28,7 @@ class IngredientServiceTest {
 
     @Mock private IngredientRepository repo;
     @Mock private IngredientMapper mapper;
+    @Mock private SimpMessagingTemplate template;
     @InjectMocks private IngredientService service;
 
     @Test
@@ -51,6 +54,7 @@ class IngredientServiceTest {
         responseDTO.setQuantity(new BigDecimal("5"));
 
         when(repo.save(any())).thenReturn(saved);
+        when(repo.findAll(any(org.springframework.data.domain.Pageable.class))).thenReturn(new org.springframework.data.domain.PageImpl<>(List.of()));
         when(mapper.toEntity(any())).thenReturn(ing);
         when(mapper.toDTO(any())).thenReturn(responseDTO);
 
@@ -59,6 +63,7 @@ class IngredientServiceTest {
         assertNotNull(result.getId());
         assertEquals("Apple", result.getName());
         verify(repo).save(any());
+        verify(template).convertAndSend(anyString(), any(Object.class));
     }
 
     @Test
@@ -83,8 +88,10 @@ class IngredientServiceTest {
     void shouldDeleteIngredient() {
         UUID id = UUID.randomUUID();
         when(repo.existsById(id)).thenReturn(true);
+        when(repo.findAll(any(org.springframework.data.domain.Pageable.class))).thenReturn(new org.springframework.data.domain.PageImpl<>(List.of()));
         service.delete(id);
         verify(repo).deleteById(id);
+        verify(template).convertAndSend(anyString(), any(Object.class));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- decrease ingredient quantities when creating prepared foods
- restore ingredient quantities when deleting prepared foods
- send websocket events on ingredient/prepared food create or delete
- add controller endpoint to delete prepared foods
- update and extend unit/integration tests

## Testing
- `./gradlew test --no-daemon` *(fails: IllegalStateException while loading Spring context)*

------
https://chatgpt.com/codex/tasks/task_e_686af794641c832ca17bf0a5bad75eb7