### PR TITLE
Fix prepared food deletion test

### DIFF
--- a/src/main/java/com/leultewolde/hidmo/kmingredientsservice/dto/response/PreparedFoodResponseDTO.java
+++ b/src/main/java/com/leultewolde/hidmo/kmingredientsservice/dto/response/PreparedFoodResponseDTO.java
@@ -13,6 +13,7 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 public class PreparedFoodResponseDTO {
+    private java.util.UUID id;
     private String name;
     private BigDecimal quantity;
     private String unit;

--- a/src/test/java/com/leultewolde/hidmo/kmingredientsservice/integration/PreparedFoodControllerIT.java
+++ b/src/test/java/com/leultewolde/hidmo/kmingredientsservice/integration/PreparedFoodControllerIT.java
@@ -39,6 +39,7 @@ class PreparedFoodControllerIT {
 
     @BeforeEach
     void setup() {
+        preparedFoodRepository.deleteAll();
         IngredientRequestDTO ing = new IngredientRequestDTO(
                 "Chili", new BigDecimal("2.0"), "cups",
                 new BigDecimal("1.00"), LocalDate.now(),

--- a/src/test/java/com/leultewolde/hidmo/kmingredientsservice/integration/PreparedFoodServiceIntegrationTest.java
+++ b/src/test/java/com/leultewolde/hidmo/kmingredientsservice/integration/PreparedFoodServiceIntegrationTest.java
@@ -85,8 +85,8 @@ class PreparedFoodServiceIntegrationTest {
                 IngredientStatus.AVAILABLE, null, List.of(usage)
         );
 
-        preparedFoodService.createPreparedFood(dto);
-        UUID foodId = preparedFoodRepository.findAll().getFirst().getId();
+        PreparedFoodResponseDTO created = preparedFoodService.createPreparedFood(dto);
+        UUID foodId = created.getId();
 
         preparedFoodService.deletePreparedFood(foodId);
 

--- a/src/test/java/com/leultewolde/hidmo/kmingredientsservice/integration/PreparedFoodServiceIntegrationTest.java
+++ b/src/test/java/com/leultewolde/hidmo/kmingredientsservice/integration/PreparedFoodServiceIntegrationTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -22,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @ActiveProfiles("test")
+@TestPropertySource(properties = "spring.jpa.hibernate.ddl-auto=create-drop")
 class PreparedFoodServiceIntegrationTest {
 
     @Autowired
@@ -90,6 +92,6 @@ class PreparedFoodServiceIntegrationTest {
 
         preparedFoodService.deletePreparedFood(foodId);
 
-        assertEquals(new BigDecimal("2"), ingredientService.getById(ingId).getQuantity());
+        assertEquals(0, ingredientService.getById(ingId).getQuantity().compareTo(new BigDecimal("2")));
     }
 }


### PR DESCRIPTION
## Summary
- include `id` in PreparedFoodResponseDTO
- reset repository before controller tests
- fetch created prepared food id directly from service in integration test

## Testing
- `./gradlew testClasses`
- `./gradlew test --tests *PreparedFoodServiceIntegrationTest.deletingPreparedFoodRestoresIngredientQuantities` *(fails: SchemaManagementException)*

------
https://chatgpt.com/codex/tasks/task_e_686b1fdd6eb8832cb2fb82c193cd31fa