### PR TITLE
Handle duplicate barcode on ingredient creation

### DIFF
--- a/src/test/java/com/leultewolde/hidmo/kmingredientsservice/integration/IngredientControllerIT.java
+++ b/src/test/java/com/leultewolde/hidmo/kmingredientsservice/integration/IngredientControllerIT.java
@@ -51,6 +51,26 @@ class IngredientControllerIT {
     }
 
     @Test
+    void postingExistingBarcodeAddsQuantity() throws Exception {
+        IngredientRequestDTO dto = sampleDTO();
+        mockMvc.perform(post("/v1/ingredients")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isCreated());
+
+        dto.setQuantity(BigDecimal.valueOf(0.5));
+
+        mockMvc.perform(post("/v1/ingredients")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(get("/v1/ingredients/by-barcode/" + dto.getBarcode()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.quantity", is(2.0)));
+    }
+
+    @Test
     void shouldValidateMissingFields() throws Exception {
         mockMvc.perform(post("/v1/ingredients")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/com/leultewolde/hidmo/kmingredientsservice/integration/IngredientServiceIntegrationTest.java
+++ b/src/test/java/com/leultewolde/hidmo/kmingredientsservice/integration/IngredientServiceIntegrationTest.java
@@ -70,6 +70,7 @@ class IngredientServiceIntegrationTest {
         service.create(dto);
 
         IngredientResponseDTO result = service.getById(firstId);
-        assertEquals(new BigDecimal("1.5"), result.getQuantity());
+        assertEquals(new BigDecimal("1.5").stripTrailingZeros(),
+                result.getQuantity().stripTrailingZeros());
     }
 }

--- a/src/test/java/com/leultewolde/hidmo/kmingredientsservice/integration/IngredientServiceIntegrationTest.java
+++ b/src/test/java/com/leultewolde/hidmo/kmingredientsservice/integration/IngredientServiceIntegrationTest.java
@@ -60,4 +60,16 @@ class IngredientServiceIntegrationTest {
         UUID id = service.create(dto).getId();
         assertEquals(IngredientStatus.AVAILABLE, service.getById(id).getStatus());
     }
+
+    @Test
+    void createWithExistingBarcodeAddsQuantity() {
+        IngredientRequestDTO dto = getSampleDTO();
+        UUID firstId = service.create(dto).getId();
+
+        dto.setQuantity(new BigDecimal("1.0"));
+        service.create(dto);
+
+        IngredientResponseDTO result = service.getById(firstId);
+        assertEquals(new BigDecimal("1.5"), result.getQuantity());
+    }
 }

--- a/src/test/java/com/leultewolde/hidmo/kmingredientsservice/service/IngredientServiceTest.java
+++ b/src/test/java/com/leultewolde/hidmo/kmingredientsservice/service/IngredientServiceTest.java
@@ -69,6 +69,44 @@ class IngredientServiceTest {
     }
 
     @Test
+    void shouldUpdateQuantityWhenBarcodeExists() {
+        IngredientRequestDTO dto = new IngredientRequestDTO();
+        dto.setName("Apple");
+        dto.setQuantity(new BigDecimal("5"));
+        dto.setBarcode("123");
+
+        Ingredient existing = new Ingredient();
+        existing.setId(UUID.randomUUID());
+        existing.setName("Apple");
+        existing.setQuantity(new BigDecimal("2"));
+        existing.setBarcode("123");
+        existing.setStatus(IngredientStatus.AVAILABLE);
+
+        Ingredient updated = new Ingredient();
+        updated.setId(existing.getId());
+        updated.setName("Apple");
+        updated.setQuantity(new BigDecimal("7"));
+        updated.setBarcode("123");
+        updated.setStatus(IngredientStatus.AVAILABLE);
+
+        IngredientResponseDTO dtoResp = new IngredientResponseDTO();
+        dtoResp.setId(existing.getId());
+        dtoResp.setName("Apple");
+        dtoResp.setQuantity(new BigDecimal("7"));
+
+        when(repo.findByBarcode("123")).thenReturn(Optional.of(existing));
+        when(repo.save(existing)).thenReturn(updated);
+        when(repo.findAll(any(org.springframework.data.domain.Pageable.class))).thenReturn(new org.springframework.data.domain.PageImpl<>(List.of()));
+        when(mapper.toDTO(updated)).thenReturn(dtoResp);
+
+        IngredientResponseDTO result = service.create(dto);
+
+        assertEquals(new BigDecimal("7"), result.getQuantity());
+        verify(repo).save(existing);
+        verify(template).convertAndSend(anyString(), any(Object.class));
+    }
+
+    @Test
     void shouldReturnAllIngredients() {
         IngredientResponseDTO dto = new IngredientResponseDTO();
         dto.setId(UUID.randomUUID());


### PR DESCRIPTION
## Summary
- update `IngredientService#create` to merge quantity and status when creating an ingredient with an existing barcode
- add unit test for new create logic
- add integration tests to validate quantity accumulation via service and controller

## Testing
- `./gradlew test --no-daemon` *(fails: PreparedFoodMapperTest etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687bb0fcf808832cb1e4bb6c1893a53d