### PR TITLE
Define ingredient topic constant

### DIFF
--- a/src/main/java/com/leultewolde/hidmo/kmingredientsservice/constant/WebSocketTopics.java
+++ b/src/main/java/com/leultewolde/hidmo/kmingredientsservice/constant/WebSocketTopics.java
@@ -1,0 +1,11 @@
+package com.leultewolde.hidmo.kmingredientsservice.constant;
+
+/**
+ * Central place for WebSocket topic names to avoid repeated literals.
+ */
+public final class WebSocketTopics {
+    private WebSocketTopics() {}
+
+    public static final String INGREDIENTS = "/topic/ingredients";
+    public static final String PREPARED_FOODS = "/topic/prepared-foods";
+}

--- a/src/main/java/com/leultewolde/hidmo/kmingredientsservice/controller/IngredientWebSocketController.java
+++ b/src/main/java/com/leultewolde/hidmo/kmingredientsservice/controller/IngredientWebSocketController.java
@@ -4,6 +4,7 @@ import com.leultewolde.hidmo.kmingredientsservice.dto.response.IngredientRespons
 import com.leultewolde.hidmo.kmingredientsservice.dto.response.PreparedFoodResponseDTO;
 import com.leultewolde.hidmo.kmingredientsservice.service.IngredientService;
 import com.leultewolde.hidmo.kmingredientsservice.service.PreparedFoodService;
+import com.leultewolde.hidmo.kmingredientsservice.constant.WebSocketTopics;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.SendTo;
@@ -20,13 +21,13 @@ public class IngredientWebSocketController {
     private final PreparedFoodService preparedFoodService;
 
     @MessageMapping("/ingredients")
-    @SendTo("/topic/ingredients")
+    @SendTo(WebSocketTopics.INGREDIENTS)
     public List<IngredientResponseDTO> streamIngredients() {
         return ingredientService.getAll(PageRequest.of(0, 20));
     }
 
     @MessageMapping("/prepared-foods")
-    @SendTo("/topic/prepared-foods")
+    @SendTo(WebSocketTopics.PREPARED_FOODS)
     public List<PreparedFoodResponseDTO> streamPreparedFoods() {
         return preparedFoodService.getAllPreparedFoods(PageRequest.of(0, 20));
     }

--- a/src/main/java/com/leultewolde/hidmo/kmingredientsservice/service/IngredientService.java
+++ b/src/main/java/com/leultewolde/hidmo/kmingredientsservice/service/IngredientService.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.PageRequest;
+import com.leultewolde.hidmo.kmingredientsservice.constant.WebSocketTopics;
 
 import java.util.List;
 import java.util.UUID;
@@ -43,7 +44,7 @@ public class IngredientService {
                 existing.setQuantity(existing.getQuantity().add(dto.getQuantity()));
                 existing.setStatus(dto.getStatus() != null ? dto.getStatus() : existing.getStatus());
                 IngredientResponseDTO saved = mapper.toDTO(repo.save(existing));
-                ws.convertAndSend("/topic/ingredients", getAll(PageRequest.of(0, 20)));
+                ws.convertAndSend(WebSocketTopics.INGREDIENTS, getAll(PageRequest.of(0, 20)));
                 return saved;
             }
         }
@@ -53,7 +54,7 @@ public class IngredientService {
             ing.setStatus(IngredientStatus.AVAILABLE);
         }
         IngredientResponseDTO saved = mapper.toDTO(repo.save(ing));
-        ws.convertAndSend("/topic/ingredients", getAll(PageRequest.of(0, 20)));
+        ws.convertAndSend(WebSocketTopics.INGREDIENTS, getAll(PageRequest.of(0, 20)));
         return saved;
     }
 
@@ -68,6 +69,6 @@ public class IngredientService {
             throw new ResourceNotFoundException("Ingredient", "id", id);
         }
         repo.deleteById(id);
-        ws.convertAndSend("/topic/ingredients", getAll(PageRequest.of(0, 20)));
+        ws.convertAndSend(WebSocketTopics.INGREDIENTS, getAll(PageRequest.of(0, 20)));
     }
 }

--- a/src/main/java/com/leultewolde/hidmo/kmingredientsservice/service/PreparedFoodService.java
+++ b/src/main/java/com/leultewolde/hidmo/kmingredientsservice/service/PreparedFoodService.java
@@ -19,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import com.leultewolde.hidmo.kmingredientsservice.constant.WebSocketTopics;
 
 import java.util.List;
 import java.util.UUID;
@@ -64,7 +65,7 @@ public class PreparedFoodService {
 
         food.setIngredientsUsed(usageList);
         PreparedFoodResponseDTO saved = mapper.toDTO(preparedFoodRepo.save(food));
-        ws.convertAndSend("/topic/prepared-foods", fetchPreparedFoods(PageRequest.of(0, 20)));
+        ws.convertAndSend(WebSocketTopics.PREPARED_FOODS, fetchPreparedFoods(PageRequest.of(0, 20)));
         return saved;
     }
 
@@ -91,7 +92,7 @@ public class PreparedFoodService {
         }
 
         preparedFoodRepo.deleteById(id);
-        ws.convertAndSend("/topic/prepared-foods", fetchPreparedFoods(PageRequest.of(0, 20)));
+        ws.convertAndSend(WebSocketTopics.PREPARED_FOODS, fetchPreparedFoods(PageRequest.of(0, 20)));
     }
 
     private List<PreparedFoodResponseDTO> fetchPreparedFoods(Pageable pageable) {

--- a/src/test/java/com/leultewolde/hidmo/kmingredientsservice/websocket/WebSocketSubscriptionIT.java
+++ b/src/test/java/com/leultewolde/hidmo/kmingredientsservice/websocket/WebSocketSubscriptionIT.java
@@ -3,6 +3,7 @@ package com.leultewolde.hidmo.kmingredientsservice.websocket;
 import com.leultewolde.hidmo.kmingredientsservice.dto.request.IngredientRequestDTO;
 import com.leultewolde.hidmo.kmingredientsservice.model.IngredientStatus;
 import com.leultewolde.hidmo.kmingredientsservice.service.IngredientService;
+import com.leultewolde.hidmo.kmingredientsservice.constant.WebSocketTopics;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -52,7 +53,7 @@ class WebSocketSubscriptionIT {
                         new StompSessionHandlerAdapter() {})
                 .get(3, TimeUnit.SECONDS);
 
-        session.subscribe("/topic/ingredients", new StompFrameHandler() {
+        session.subscribe(WebSocketTopics.INGREDIENTS, new StompFrameHandler() {
             @NotNull
             @Override
             public Type getPayloadType(@NotNull StompHeaders headers) {


### PR DESCRIPTION
## Summary
- avoid repeated `"/topic/ingredients"` string
- apply the constant in controller and tests
- centralize websocket topics

## Testing
- `./gradlew test --no-daemon` *(fails: IllegalStateException at DefaultCacheAwareContextLoaderDelegate)*

------
https://chatgpt.com/codex/tasks/task_e_687bb6cfc0c4832c9fb380be022ea5c3